### PR TITLE
Update gem dependency

### DIFF
--- a/monologue_image_upload.gemspec
+++ b/monologue_image_upload.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   #s.add_dependency "monologue", "~> 4.0"
   s.add_dependency "monologue"
   s.add_dependency "jquery-rails"
-  s.add_dependency 'paperclip', '~> 3.4.1'
+  s.add_dependency 'paperclip', '~> 3.5.4'
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency 'rspec-rails', '2.14.0'


### PR DESCRIPTION
Compatible with any Rails version higher than 4.0.0 and lower than 4.2.0.
Update paperclip dependency to 3.5.4.
